### PR TITLE
Support for Webpack 2.x

### DIFF
--- a/archetype/config/webpack.js
+++ b/archetype/config/webpack.js
@@ -14,21 +14,12 @@ module.exports = {
       publicPath: '/dist/'
     },
     module: {
-      loaders: [{
+      rules: [{
         test: /\.js$/,
         loader: 'babel',
         query: {
           presets: ['es2015', 'stage-0']
         }
-      }, {
-        test: /\.css$/,
-        loader: 'style-loader!css-loader'
-      }, {
-        test: /\.(ttf|otf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
-        loader: 'file-loader?name=fonts/[name].[ext]'
-      }, {
-        test: /\.(png|jpg)$/,
-        loader: 'url?limit=25000'
       }]
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "^2.5.1"
   },
   "peerDependencies": {
-    "webpack": "^1.13.0"
+    "webpack": "^2.1.0-beta.28,"
   },
   "dependencies": {
     "babel-core": "^6.9.0",
@@ -45,6 +45,6 @@
     "css-loader": "^0.23.1",
     "style-loader": "^0.13.1",
     "trailpack": "^1.0.2",
-    "webpack": "^1.13.0"
+    "webpack": "^2.1.0-beta.28,"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "^2.5.1"
   },
   "peerDependencies": {
-    "webpack": "^2.1.0-beta.28,"
+    "webpack": "^2.1.0-beta.28"
   },
   "dependencies": {
     "babel-core": "^6.9.0",
@@ -45,6 +45,6 @@
     "css-loader": "^0.23.1",
     "style-loader": "^0.13.1",
     "trailpack": "^1.0.2",
-    "webpack": "^2.1.0-beta.28,"
+    "webpack": "^2.1.0-beta.28"
   }
 }


### PR DESCRIPTION
Supporting webpack 2.x isn't very hard as this PR shows.

In regards to trailpacks version numbering, would a separate `trailpack-webpack2` npm module be a better option than a new branch here?

(BTW I removed all the rules except for loading js files using babel-loader in this PR)